### PR TITLE
refactor(html): починить валидность вёрстки

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
           <template class="elements__template">
             <li class="card">
               <div class="card__image-wrapper">
-                <img src="" class="card__image">
+                <img src="#" class="card__image">
               </div>
               <button type="button" class="card__remove-button"></button>
               <div class="card__footer">
@@ -82,7 +82,7 @@
       <button type="button" class="popup__close-button popup__close-button_preview">
       </button>
       <figure class="preview">
-        <img src="" class="preview__image">
+        <img src="#" alt="" class="preview__image">
         <figcaption class="preview__caption"></figcaption>
       </figure>
     </div>


### PR DESCRIPTION
Вёрстка не проходит W3C валидатор без атрибута alt и с пустым
атрибутом src у картинок. Исправлено.