### PR TITLE
refactor(validate): переписать валидацию инпутов

### DIFF
--- a/blocks/popup/__input-error/popup__input-error.css
+++ b/blocks/popup/__input-error/popup__input-error.css
@@ -1,5 +1,4 @@
 .popup__input-error {
-  display: none;
   font-size: 12px;
   line-height: 1.25;
   color: #ff0000;

--- a/blocks/popup/__input/_state/popup__input_state_invalid.css
+++ b/blocks/popup/__input/_state/popup__input_state_invalid.css
@@ -1,3 +1,3 @@
-.popup__input_type_error {
+.popup__input_state_invalid {
   border-bottom: 1px solid  #ff0000;
 }

--- a/index.html
+++ b/index.html
@@ -57,10 +57,28 @@
       <h2 class="popup__title">Редактировать профиль</h2>
       <form action="submit" name="profileForm" class="popup__form" novalidate>
         <fieldset class="popup__form-fieldset">
-          <input type="text" name="profileName" placeholder="Ваше имя" class="popup__input" id="profile-name-input" minlength="2" maxlength="40" required>
-          <span class="popup__input-error profile-name-input-error"></span>
-          <input type="text" name="profileAbout" placeholder="О себе" class="popup__input" id="profile-about-input" minlength="2" maxlength="200" required>
-          <span class="popup__input-error profile-about-input-error"></span>
+          <input
+            type="text"
+            name="profileName"
+            class="popup__input"
+            id="profile-name-input"
+            minlength="2"
+            maxlength="40"
+            placeholder="Ваше имя"
+            required
+          >
+          <span class="popup__input-error" id="profile-name-input-error"></span>
+          <input
+            type="text"
+            name="profileAbout"
+            class="popup__input"
+            id="profile-about-input"
+            minlength="2"
+            maxlength="200"
+            placeholder="О себе"
+            required
+          >
+          <span class="popup__input-error" id="profile-about-input-error"></span>
           <button type="submit" class="popup__save-button">Сохранить</button>
         </fieldset>
       </form>
@@ -74,10 +92,26 @@
       <h2 class="popup__title">Новое место</h2>
       <form action="submit" name="addForm" class="popup__form popup__form_add-card" novalidate>
         <fieldset class="popup__form-fieldset">
-          <input type="text" name="cardName" placeholder="Название" class="popup__input" id="card-name-input" minlength="2" maxlength="30" required>
-          <span class="popup__input-error card-name-input-error"></span>
-          <input type="url" name="cardLink" placeholder="Ссылка на картинку" class="popup__input" id="card-link-input" required>
-          <span class="popup__input-error card-link-input-error"></span>
+          <input
+            type="text"
+            name="cardName"
+            class="popup__input"
+            id="card-name-input"
+            minlength="2"
+            maxlength="30"
+            placeholder="Название"
+            required
+          >
+          <span class="popup__input-error" id="card-name-input-error"></span>
+          <input
+            type="url"
+            name="cardLink"
+            class="popup__input"
+            id="card-link-input"
+            placeholder="Ссылка на картинку"
+            required
+          >
+          <span class="popup__input-error" id="card-link-input-error"></span>
           <button type="submit" class="popup__save-button">Создать</button>
         </fieldset>
       </form>

--- a/pages/index.css
+++ b/pages/index.css
@@ -54,7 +54,7 @@
 @import url('../blocks/popup/__form/popup__form.css');
 @import url('../blocks/popup/__form-fieldset/popup__form-fieldset.css');
 @import url('../blocks/popup/__input/popup__input.css');
-@import url('../blocks/popup/__input/_type_error/popup__input_type_error.css');
+@import url('../blocks/popup/__input/_state/popup__input_state_invalid.css');
 @import url('../blocks/popup/__input-error/popup__input-error.css');
 @import url('../blocks/popup/__input-error/_active/popup__input-error_active.css');
 @import url('../blocks/popup/__save-button/popup__save-button.css');

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,4 +1,4 @@
-const anyPopup = document.querySelector('.popup');
+const activePopup = document.querySelector('.popup');
 const popupEditProfile = document.querySelector('.popup_edit-profile');
 const popupAddCard = document.querySelector('.popup_add-card');
 const popupPreview = document.querySelector('.popup_preview');
@@ -117,13 +117,13 @@ function handleEditProfileFormSubmit(evt) {
 }
 
 // открытие попапа
-function openPopup(anyPopup) {
-  anyPopup.classList.add('popup_opened');
+function openPopup(activePopup) {
+  activePopup.classList.add('popup_opened');
 }
 
 // закрытие попапа
-function closePopup(anyPopup) {
-  anyPopup.classList.remove('popup_opened');
+function closePopup(activePopup) {
+  activePopup.classList.remove('popup_opened');
 }
 
 // обработчик клика по крестику

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,57 +1,40 @@
 const formElement = document.querySelector('.popup__form');
-const formInput = formElement.querySelector('.popup__input');
+const inputElement = formElement.querySelector('.popup__input');
+const inputList = formElement.querySelectorAll('.popup__input');
 
-// показать красный нижний бордер при ошибке валидации инпута
-const showInputError = (formElement, inputElement, errorMessage) => {
-  const errorElement = formElement.querySelector(`.${inputElement.id}-error`);
-  inputElement.classList.add('popup__input_type_error');
-  errorElement.textContent = errorMessage;
-  errorElement.classList.add('popup__input-error_active');
-};
+// показать красный нижний бордер и текст при ошибке валидации инпута
+function showInputError(form, input) {
+  const errorElement = form.querySelector(`#${input.id}-error`);
+  errorElement.textContent = input.validationMessage;
+  input.classList.add('popup__input_state_invalid');
+}
 
-// скрыть тот же бордер при пройденной валидации
-const hideInputError = (inputElement) => {
-  const errorElement = formElement.querySelector(`.${inputElement.id}-error`);
-  inputElement.classList.remove('popup__input_type_error');
-  errorElement.classList.remove('popup__input-error_active');
+// скрыть тот же бордер и текст ошибки при пройденной валидации
+function hideInputError(form, input) {
+  const errorElement = form.querySelector(`#${input.id}-error`);
   errorElement.textContent = '';
-};
+  input.classList.remove('popup__input_state_invalid');
+}
 
 // проверка валидности поля
-const isValid = (formElement, inputElement) => {
-  if (!inputElement.validity.valid) {
-    showInputError(formElement, inputElement, inputElement.validationMessage);
+function isValid(checkForm, checkInput) {
+  if (!checkInput.validity.valid) {
+    showInputError(checkForm, checkInput)
   } else {
-    hideInputError(formElement, inputElement);
+    hideInputError(checkForm, checkInput);
   }
-};
-
-// добавление обработчиков всем полям формы
-const setEventListener = (formElement) => {
-  const inputList = Array.from(formElement.querySelectorAll('.popup__input'));
-  inputList.forEach((inputElement) => {
-    inputElement.addEventListener('input', () => {
-      isValid(formElement, inputElement);
-    });
-  });
-};
-
-const enableValidation = () => {
-  const formList = Array.from(document.querySelectorAll('.popup__form'));
-  formList.forEach((formElement) => {
-    formElement.addEventListener('submit', (evt) => {
-      evt.preventDefault();
-    });
-    setEventListener(formElement);
-  });
 }
-enableValidation();
 
+// слушатель с проверкой валидности для каждого импута
+inputList.forEach(currentInput => {
+  currentInput.addEventListener('input', (evt) => {
+    isValid(formElement, currentInput);
+  })
+})
 
-//отмена стандартного поведения формы
+// сброс дефолтного поведения
 formElement.addEventListener('submit', (evt) => {
   evt.preventDefault();
 });
 
-//проверяем инпуты при вводе символов
-formInput.addEventListener('input', isValid);
+


### PR DESCRIPTION
- Отрезал кривой функционал валидации всех форм, вернул состояние, при
  котором валидация работает в рамках только одной формы.
- errorElement.textContent теперь принимает у инпута непосредственно
  .validationMessage, это позволяет отказаться от необходимости скрывать
  со страницы сам элемент текста ошибки.
- Переименовал popup__input_type_error.css в
  popup__input_state_invalid.css. Папки также переименованы, импорт
  переписан.
- Переменная anyPopup переименована в activePopup.
- Привёл к удобоваримому виду зоопарк атрибутов инпутов в вёрстке.