### PR TITLE
refactor: вынести превью карточек из класса Card

### DIFF
--- a/scripts/components/Card.js
+++ b/scripts/components/Card.js
@@ -1,9 +1,3 @@
-const popupPreview = document.querySelector('.popup_preview');
-
-const previewImage = popupPreview.querySelector('.preview__image');
-const previewCaption = popupPreview.querySelector('.preview__caption');
-const previewCloseButton = popupPreview.querySelector('.popup__close-button_preview');
-
 export default class Card {
   constructor(data, cardSelector) {
     this._name = data.name;
@@ -35,18 +29,6 @@ export default class Card {
     return this._element;
   }
 
-  // открытие предпросмотра изображения
-  _handleOpenPreview() {
-    previewCaption.textContent = this._name;
-    previewImage.src = this._image;
-    popupPreview.classList.add('popup_opened');
-  }
-
-  // закрытие предпросмотра по клику на крестик
-  _handleClosePreview() {
-    popupPreview.classList.remove('popup_opened');
-  }
-
   // лайк карточки
   _cardLikeToggle(evt) {
     evt.target.classList.toggle('card__like-button_active');
@@ -59,12 +41,6 @@ export default class Card {
 
   // слушатели кликов
   _setEventListeners() {
-    this._element.querySelector('.card__image').addEventListener('click', () => {
-      this._handleOpenPreview();
-    })
-    previewCloseButton.addEventListener('click', () => {
-      this._handleClosePreview();
-    })
     this._element.querySelector('.card__like-button').addEventListener('click', (evt) => {
       this._cardLikeToggle(evt);
     })

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -3,18 +3,22 @@ import Card from './components/Card.js'
 
 const popupEditProfile = document.querySelector('.popup_edit-profile');
 const popupAddCard = document.querySelector('.popup_add-card');
+const popupPreview = document.querySelector('.popup_preview');
+
+const previewImage = popupPreview.querySelector('.preview__image');
+const previewCaption = popupPreview.querySelector('.preview__caption');
 
 const popupCloseButtons = [...document.querySelectorAll('.popup__close-button')];
 
 const nameInput = document.querySelector('.popup__input[name="profileName"]');
 const aboutInput = document.querySelector('.popup__input[name="profileAbout"]');
+const cardNameInput = document.querySelector('.popup__input[name="cardName"]');
+const cardImageInput = document.querySelector('.popup__input[name="cardImage"]');
+
 const profileName = document.querySelector('.profile__name');
 const profileAbout = document.querySelector('.profile__about');
 
 const addCardButton = document.querySelector('.profile__add-button');
-const cardNameInput = document.querySelector('.popup__input[name="cardName"]');
-const cardImageInput = document.querySelector('.popup__input[name="cardImage"]');
-
 const popupFormAddCard = document.querySelector('.popup__form_add-card');
 
 const cardsContainerElement = document.querySelector('.elements__list');
@@ -25,6 +29,24 @@ initialCards.forEach((item) => {
   const cardElement = card.generateCard();
   document.querySelector('.elements__list').append(cardElement);
 })
+
+// открытие предпросмотра изображения
+/* TODO: картинка, по которой производится клик, открывается в попапе предпросмотра,
+*   но описание под картинкой не подтягивается из cardHeading.
+*   Нужно разобраться, почему туда попадает undefined и как это исправить
+*/
+function handleOpenPreview() {
+  const cardHeadings = [...document.querySelectorAll('.card__heading')];
+  const cardImages = [...document.querySelectorAll('.card__image')];
+  cardImages.forEach((cardImage) => {
+    cardImage.addEventListener('click', (evt) => {
+      previewImage.src = cardImage.src;
+      previewImage.alt = cardImage.alt;
+      previewCaption.textContent = cardHeadings.textContent;
+      openPopup(popupPreview);
+    });
+  })
+}
 
 // первоначальный рендер списка карточек
 // function renderList() {
@@ -146,3 +168,4 @@ popupFormAddCard.addEventListener('submit', handleAddCardFormSubmit);
 
 initEditProfilePopup();
 initAddNewCardPopup();
+handleOpenPreview();


### PR DESCRIPTION
Попап с предпросмотром карточки не должен относиться к классу Card, хоть и велик соблазн запихнуть его именно туда.  Вынес в отдельную функцию код, который отвечает за открытие попапа и подтягивание туда картинки и подписи. С последним пока проблема: не сообразил, как реализовать вывод в описание картинки названия карточки. Оставил комментарий в коде с TODO на будущее.