### PR TITLE
fix(сard): починить подписи к изображениям превью

### DIFF
--- a/scripts/components/Card.js
+++ b/scripts/components/Card.js
@@ -1,3 +1,5 @@
+import {openPopup} from '../index.js'
+
 const popupPreview = document.querySelector('.popup_preview');
 const previewImage = popupPreview.querySelector('.preview__image');
 const previewCaption = popupPreview.querySelector('.preview__caption');
@@ -25,7 +27,7 @@ export default class Card {
     previewImage.src = this._image;
     previewImage.alt = this._name;
     previewCaption.textContent = this._name;
-    popupPreview.classList.add('popup_opened');
+    openPopup(popupPreview);
   }
 
   // лайк карточки (вкл/выкл)

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -3,10 +3,6 @@ import Card from './components/Card.js'
 
 const popupEditProfile = document.querySelector('.popup_edit-profile');
 const popupAddCard = document.querySelector('.popup_add-card');
-const popupPreview = document.querySelector('.popup_preview');
-
-const previewImage = popupPreview.querySelector('.preview__image');
-const previewCaption = popupPreview.querySelector('.preview__caption');
 
 const popupCloseButtons = [...document.querySelectorAll('.popup__close-button')];
 
@@ -29,24 +25,6 @@ initialCards.forEach((item) => {
   const cardElement = card.generateCard();
   document.querySelector('.elements__list').append(cardElement);
 })
-
-// открытие предпросмотра изображения
-/* TODO: картинка, по которой производится клик, открывается в попапе предпросмотра,
-*   но описание под картинкой не подтягивается из cardHeading.
-*   Нужно разобраться, почему туда попадает undefined и как это исправить
-*/
-function handleOpenPreview() {
-  const cardHeadings = [...document.querySelectorAll('.card__heading')];
-  const cardImages = [...document.querySelectorAll('.card__image')];
-  cardImages.forEach((cardImage) => {
-    cardImage.addEventListener('click', (evt) => {
-      previewImage.src = cardImage.src;
-      previewImage.alt = cardImage.alt;
-      previewCaption.textContent = cardHeadings.textContent;
-      openPopup(popupPreview);
-    });
-  })
-}
 
 // первоначальный рендер списка карточек
 // function renderList() {
@@ -127,7 +105,7 @@ function handleEditProfileFormSubmit(evt) {
 }
 
 // открытие попапа
-function openPopup(popup) {
+export function openPopup(popup) {
   document.addEventListener('keydown', closeByPressingEscape);
   document.addEventListener('click', closeByClickingOverlay);
   popup.classList.add('popup_opened');


### PR DESCRIPTION
Ломал голову над тем, почему с переписанным классом по-прежнему не приходят описания картинок в превью. Оказалось, что я криво смержил ветки и оставил кривой код в index.js.

Также импортировал функцию openPopup в файл класса Card из index.js и вызвал её в методе _handleOpenPreview() чтобы не писать велосипед. 
Карточки снова заработали как следует.