### PR TITLE
bugfix: убрать form из параметров методов

### DIFF
--- a/scripts/components/FormValidator.js
+++ b/scripts/components/FormValidator.js
@@ -6,47 +6,47 @@ export default class FormValidator {
   }
 
   // показать красный нижний бордер и текст при ошибке валидации инпута
-  _showInputError(form, input) {
-    const errorElement = form.querySelector(`#${input.id}-error`);
+  _showInputError(input) {
+    const errorElement = this._formElement.querySelector(`#${input.id}-error`);
     errorElement.textContent = input.validationMessage;
     input.classList.add(this._setOfValidationsParams.inputInvalidClass);
   }
 
   // скрыть тот же бордер и текст ошибки при пройденной валидации
-  _hideInputError(form, input) {
-    const errorElement = form.querySelector(`#${input.id}-error`);
+  _hideInputError(input) {
+    const errorElement = this._formElement.querySelector(`#${input.id}-error`);
     errorElement.textContent = '';
     input.classList.remove(this._setOfValidationsParams.inputInvalidClass);
   }
 
   // проверка валидности поля
-  _isValid(checkForm, checkInput) {
+  _isValid(checkInput) {
     if (!checkInput.validity.valid) {
-      this._showInputError(checkForm, checkInput)
+      this._showInputError(checkInput);
     } else {
-      this._hideInputError(checkForm, checkInput);
+      this._hideInputError(checkInput);
     }
   }
 
   // проверка состояния кнопки submit
-  _setButtonState(button, isActive) {
-    if (!isActive) {
-      button.classList.add(this._setOfValidationsParams.buttonInvalidClass);
-      button.disabled = true;
+  _setButtonState() {
+    if (!this._formElement.checkValidity()) {
+      this._submitButton.classList.add(this._setOfValidationsParams.buttonInvalidClass);
+      this._submitButton.disabled = true;
     } else {
-      button.classList.remove(this._setOfValidationsParams.buttonInvalidClass);
-      button.disabled = false;
+      this._submitButton.classList.remove(this._setOfValidationsParams.buttonInvalidClass);
+      this._submitButton.disabled = false;
     }
   }
 
   // валидация формы
-  _setEventListener(form) {
-    const inputList = form.querySelectorAll(this._setOfValidationsParams.inputSelector);
+  _setEventListener() {
+    const inputList = this._formElement.querySelectorAll(this._setOfValidationsParams.inputSelector);
     // слушатель с проверкой валидности для каждого импута
     inputList.forEach(currentInput => {
       currentInput.addEventListener('input', () => {
-        this._isValid(form, currentInput);
-        this._setButtonState(this._submitButton, form.checkValidity());
+        this._isValid(currentInput);
+        this._setButtonState();
       })
     })
   }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -5,8 +5,6 @@ import Card from './components/Card.js'
 
 const popupCloseButtons = [...document.querySelectorAll('.popup__close-button')];
 
-const formElement = document.querySelector('.popup__form');
-
 const popupEditProfile = document.querySelector('.popup_edit-profile');
 const popupFormEditProfile = popupEditProfile.querySelector('.popup__form_edit-profile');
 const nameInput = popupFormEditProfile.querySelector('.popup__input[name="profileName"]');
@@ -118,7 +116,7 @@ popupCloseButtons.forEach((closeButton) => {
   });
 })
 
-formElement.addEventListener('submit', handleEditProfileFormSubmit);
+popupFormEditProfile.addEventListener('submit', handleEditProfileFormSubmit);
 popupFormAddCard.addEventListener('submit', handleAddCardFormSubmit);
 
 initEditProfilePopup();


### PR DESCRIPTION
*  По привычке взялся пробрасывать параметры из метода в метод, но теперь это не нужно. Обращение к форме теперь осуществляется непосредственно через this._formElement внутри методов.
*  В index.js удалил ненужную переменную formElement, а листнер сабмита формы редактирования профиля повесил на popupFormEditProfile.