### PR TITLE
bugfix: проверять состояние кнопки открытой формы

### DIFF
--- a/scripts/components/FormValidator.js
+++ b/scripts/components/FormValidator.js
@@ -29,7 +29,7 @@ export default class FormValidator {
   }
 
   // проверка состояния кнопки submit
-  _setButtonState() {
+  setButtonState() {
     if (!this._formElement.checkValidity()) {
       this._submitButton.classList.add(this._setOfValidationsParams.buttonInvalidClass);
       this._submitButton.disabled = true;
@@ -46,7 +46,7 @@ export default class FormValidator {
     inputList.forEach(currentInput => {
       currentInput.addEventListener('input', () => {
         this._isValid(currentInput);
-        this._setButtonState();
+        this.setButtonState();
       })
     })
   }
@@ -55,7 +55,7 @@ export default class FormValidator {
     this._formElement.addEventListener('submit', (evt) => {
       evt.preventDefault();
     });
-
-    this._setEventListener(this._formElement);
+    this.setButtonState();
+    this._setEventListener();
   }
 }


### PR DESCRIPTION
Форма добавления карточки при первом открытии имела валидную кнопку. Устранено добавлением метода, проверяющего состояние кнопки в метод активации валидации.