### PR TITLE
bugfix: добавить слушатель сброса формы

### DIFF
--- a/scripts/components/FormValidator.js
+++ b/scripts/components/FormValidator.js
@@ -1,61 +1,70 @@
 export default class FormValidator {
-  constructor(setOfValidationsParams, formElement) {
-    this._setOfValidationsParams = setOfValidationsParams;
+  constructor(setOfValidationParams, formElement) {
+    this._setOfValidationParams = setOfValidationParams;
     this._formElement = formElement;
-    this._submitButton = formElement.querySelector(this._setOfValidationsParams.submitButtonSelector);
+    this._submitButton = formElement.querySelector(this._setOfValidationParams.submitButtonSelector);
   }
 
-  // показать красный нижний бордер и текст при ошибке валидации инпута
-  _showInputError(input) {
-    const errorElement = this._formElement.querySelector(`#${input.id}-error`);
-    errorElement.textContent = input.validationMessage;
-    input.classList.add(this._setOfValidationsParams.inputInvalidClass);
-  }
-
-  // скрыть тот же бордер и текст ошибки при пройденной валидации
-  _hideInputError(input) {
-    const errorElement = this._formElement.querySelector(`#${input.id}-error`);
-    errorElement.textContent = '';
-    input.classList.remove(this._setOfValidationsParams.inputInvalidClass);
-  }
-
-  // проверка валидности поля
-  _isValid(checkInput) {
-    if (!checkInput.validity.valid) {
-      this._showInputError(checkInput);
+  // метод для проверки валидности поля
+  _isValid(input) {
+    if (!input.validity.valid) {
+      this._showInputError(input);
     } else {
-      this._hideInputError(checkInput);
+      this._hideInputError(input);
     }
   }
 
-  // проверка состояния кнопки submit
-  setButtonState() {
+  // метод отображающий красный нижний бордер и текст при ошибке валидации инпута
+  _showInputError(input) {
+    const errorElement = this._formElement.querySelector(`#${input.id}-error`);
+    errorElement.textContent = input.validationMessage;
+    input.classList.add(this._setOfValidationParams.inputInvalidClass);
+  }
+
+  // метод скрывающий красный нижний бордер и текст ошибки при пройденной валидации
+  _hideInputError(input) {
+    const errorElement = this._formElement.querySelector(`#${input.id}-error`);
+    errorElement.textContent = '';
+    input.classList.remove(this._setOfValidationParams.inputInvalidClass);
+  }
+
+  // метод меняющий состояние кнопки submit в зависимости от того, пройдена ли валидация
+  _setButtonState() {
     if (!this._formElement.checkValidity()) {
-      this._submitButton.classList.add(this._setOfValidationsParams.buttonInvalidClass);
+      this._submitButton.classList.add(this._setOfValidationParams.buttonInvalidClass);
       this._submitButton.disabled = true;
     } else {
-      this._submitButton.classList.remove(this._setOfValidationsParams.buttonInvalidClass);
+      this._submitButton.classList.remove(this._setOfValidationParams.buttonInvalidClass);
       this._submitButton.disabled = false;
     }
   }
 
-  // валидация формы
+  // метод слушателей
   _setEventListener() {
-    const inputList = this._formElement.querySelectorAll(this._setOfValidationsParams.inputSelector);
+    const inputList = this._formElement.querySelectorAll(this._setOfValidationParams.inputSelector);
+
     // слушатель с проверкой валидности для каждого импута
     inputList.forEach(currentInput => {
       currentInput.addEventListener('input', () => {
         this._isValid(currentInput);
-        this.setButtonState();
-      })
-    })
+        this._setButtonState();
+      });
+    });
+    // слушатель сброса инпутов, ошибок валидации и состояния кнопки
+    this._formElement.addEventListener('reset', () => {
+      inputList.forEach((input) => {
+        this._hideInputError(input);
+        this._submitButton.classList.add(this._setOfValidationParams.buttonInvalidClass);
+        this._submitButton.disabled = true;
+      });
+    });
   }
 
   enableValidation() {
     this._formElement.addEventListener('submit', (evt) => {
       evt.preventDefault();
     });
-    this.setButtonState();
-    this._setEventListener();
+    this._setButtonState();
+    this._setEventListener(this._formElement);
   }
 }


### PR DESCRIPTION
Форма добавления карточки, становилась валидной после ввода валидных данных в инпуты и имела возможность добавлять пустые карточки на страницу при повторном открытии, пустых инпутах и (якобы) неактивной неактивной кнопке. Исправлено костылём со сбросом формы.