### PR TITLE
bugfix: починить сброс ошибок инпутов

### DIFF
--- a/scripts/components/FormValidator.js
+++ b/scripts/components/FormValidator.js
@@ -60,11 +60,12 @@ export default class FormValidator {
     });
   }
 
+  // метод, включающий валидацию на экземпляре класса
   enableValidation() {
     this._formElement.addEventListener('submit', (evt) => {
       evt.preventDefault();
     });
-    this._setButtonState();
     this._setEventListener(this._formElement);
+    this._setButtonState();
   }
 }

--- a/scripts/pages/index.js
+++ b/scripts/pages/index.js
@@ -31,15 +31,10 @@ initialCards.forEach((item) => {
   cardsContainerElement.append(cardElement);
 })
 
-// сброс полей попапа добавления карточки на значения по умолчанию
-function resetPopupFormAddCard() {
-  popupFormAddCard.reset();
-}
-
 // инициализация попапа добавления карточки
 function initAddNewCardPopup() {
   addCardButton.addEventListener('click', () => {
-    resetPopupFormAddCard();
+    popupFormAddCard.reset();
     openPopup(popupAddCard);
   });
 }
@@ -51,7 +46,7 @@ function addNewCard() {
   const card = new Card({name: cardName, image: cardImage}, '.elements__template');
   const cardElement = card.generateCard();
   cardsContainerElement.prepend(cardElement);
-  resetPopupFormAddCard();
+  popupFormAddCard.reset();
 }
 
 // подтверждение создания карточки
@@ -65,6 +60,7 @@ function handleAddCardFormSubmit(evt) {
 function initEditProfilePopup() {
   const profileEditButton = document.querySelector('.profile__edit-button');
   profileEditButton.addEventListener('click', () => {
+  popupFormEditProfile.reset();
   nameInput.value = profileName.textContent;
   aboutInput.value = profileAbout.textContent;
   openPopup(popupEditProfile);


### PR DESCRIPTION
Оставалась сущая мелочь: ошибки в инпутах попапа редактирования профиля, если те выводились хотя бы единожды, оставались там при повторном открытии окна даже при валидных значениях. Исправлено обращением к переменной, содержащей форму редактирования профиля с методом .reset(), на котором висит листнер с функционалом сброса
ошибок валидации и проверткой состояния кнопки.

Также удалил ненужную функцию, в которой лежал сброс формы добавления карточки.