### PR TITLE
refactor: написать класс PopupWithForm

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -1,5 +1,3 @@
-
-
 export default class Card {
   constructor({card, handleOpenPreview}, cardSelector) {
     this._name = card.name;
@@ -10,22 +8,13 @@ export default class Card {
 
   // метод забирающий разметку из HTML и клонирующий элемент
   _getTemplate() {
-    const cardTemplate = document
-      .querySelector(this._cardSelector)
+    const cardTemplate = this._cardSelector
       .content
       .querySelector('.card')
       .cloneNode(true);
     // вернём DOM-элемент карточки
     return cardTemplate;
   }
-
-  // // метод открывающий предпросмотр изображения         TODO: перенести в index.js, сделать функцией, которая передаётся параметром в конструктор чтобы избавиться от кольцевого импорта
-  // _handleOpenPreview() {
-  //   previewImage.src = this._image;
-  //   previewImage.alt = this._name;
-  //   previewCaption.textContent = this._name;
-  //   openPopup(popupPreview);
-  // }
 
   // метод установки/снятия лайка карточки
   _cardLikeToggle(evt) {
@@ -38,37 +27,36 @@ export default class Card {
     this._element = null;
   }
 
-  // слушатели кликов
-  _setEventListeners() {
-
-    // слушатель клика по картинке карточки
-    this._element.querySelector('.card__image').addEventListener('click', (evt) => {
-      this._handleOpenPreview(evt);
-    });
-
-    // слушатель клика по кнопке лайка
-    this._element.querySelector('.card__like-button').addEventListener('click', (evt) => {
-      this._cardLikeToggle(evt);
-    });
-
-    // слушатель клика по корзине (кнопке удаления карточки)
-    this._element.querySelector('.card__remove-button').addEventListener('click', (evt) => {
-      this._removeCard(evt);
-    })
-  }
-
   // метод генерирующий карточку и готовящий её к публикации
   generateCard() {
     // Запишем разметку в приватное поле _element.
     // Так у других элементов появится доступ к ней.
     this._element = this._getTemplate();
     // Добавим данные
-    this._element.querySelector('.card__image').src = this._image;
-    this._element.querySelector('.card__image').alt = this._name;
-    this._element.querySelector('.card__heading').textContent = this._name;
+    this._cardImage = this._element.querySelector('.card__image');
+    this._cardCaption = this._element.querySelector('.card__heading');
 
+    this._cardImage.src = this._image;
+    this._cardImage.alt = this._name;
+    this._cardCaption.textContent = this._name;
     this._setEventListeners();
     // Вернём элемент наружу
     return this._element;
+  }
+
+  // слушатели кликов
+  _setEventListeners() {
+    this._cardImage = this._element.querySelector('.card__image');
+    this._cardLike = this._element.querySelector('.card__like-button');
+    this._remove = this._element.querySelector('.card__remove-button');
+
+    // слушатель клика по картинке карточки
+    this._cardImage.addEventListener('click', () => {this._handleOpenPreview(this._element)});
+
+    // слушатель клика по кнопке лайка
+    this._cardLike.addEventListener('click', (evt) => {this._cardLikeToggle(evt)});
+
+    // слушатель клика по корзине (кнопке удаления карточки)
+    this._remove.addEventListener('click', (evt) => {this._removeCard(evt)})
   }
 }

--- a/components/Popup.js
+++ b/components/Popup.js
@@ -1,7 +1,7 @@
 // класс отвечает за открытие/закрытие попапа
 export default class Popup {
   constructor(popupSelector) {
-    this._popup = document.querySelector(popupSelector);
+    this._popup = popupSelector;
     this._closeButton = this._popup.querySelector('.popup__close-button');
     this._handleEscClose = this._handleEscClose.bind(this);
     this._handleOverlayClose = this._handleOverlayClose.bind(this);

--- a/components/PopupWithForm.js
+++ b/components/PopupWithForm.js
@@ -1,0 +1,38 @@
+import Popup from './Popup.js';
+
+export default class PopupWithForm extends Popup {
+  constructor({popupSelector, handleForm}) {
+    super(popupSelector);
+    this._handleForm = handleForm;
+    this._handleFormSubmit = this._handleFormSubmit.bind(this);
+    this._formSelector = this._popup.querySelector('.popup__form');
+  }
+
+  // метод собирает данные всех полей формы
+  _getInputValues() {
+    // this._inputList = this._formSelector.querySelectorAll('.popup__input');  // достаём все элементы полей
+    this._inputList = Array.from(this._formSelector.querySelectorAll('.popup__input'));
+    this._formValues = {};  // создаём пустой объект
+    this._inputList.forEach(input => {  // добавляем в этот объект значения всех полей
+      this._formValues[input.name] = input.value;
+    });
+
+    return this._formValues;  // возвращаем объект значений
+  }
+
+  // метод закрывает форму и сбрасывает инпуты
+  close() {
+    this._formSelector.reset();
+    super.close();
+  }
+
+  _handleFormSubmit(evt) {
+    evt.preventDefault();
+    this._handleForm(this._getInputValues());
+  }
+
+  setEventListeners() {
+    this._formSelector.addEventListener('submit', this._handleFormSubmit);
+    super.setEventListeners();
+  }
+};

--- a/components/PopupWithImage.js
+++ b/components/PopupWithImage.js
@@ -3,16 +3,14 @@ import Popup from './Popup.js';
 export default class PopupWithImage extends Popup {
   constructor(popupSelector) {
     super(popupSelector);
+    this._previewImage = this._popup.querySelector('.preview__image');
+    this._previewCaption = this._popup.querySelector('.preview__caption');
   };
 
-  // метод открывающий предпросмотр изображения
-  open(evt) { // передаём event в метод
-    const currentImage = evt.target.closest('.card__image');  // вяжемся по event.target на картинку карточки
-    const previewImage = this._popup.querySelector('.preview__image');  // превьюшная картинка
-    const previewCaption = this._popup.querySelector('.preview__caption');  // превьюшная подпись
-    previewImage.src = currentImage.src;  // в src превьюшной картинки кладём src картинки, попавшей в event.target
-    previewImage.alt = currentImage.alt;  // то же проделываем с альтом
-    previewCaption.textContent = currentImage.alt;  // и с подписью
+  open(card) {
+    this._previewImage.src = card._image;
+    this._previewImage.alt = card._name;
+    this._previewCaption.textContent = card._name;
     super.open();
   };
 }

--- a/components/Section.js
+++ b/components/Section.js
@@ -13,6 +13,6 @@ export default class Section {
 
   // добавляет элемент в контейнер
   addItem(element) {
-    this._container.append(element);
+    this._container.prepend(element);
   }
 }

--- a/components/UserInfo.js
+++ b/components/UserInfo.js
@@ -1,0 +1,19 @@
+// класс отвечает за управление отображением информации о пользователе на странице
+export default class UserInfo {
+  constructor(userName, userJob) {
+    this._userName = document.querySelector(userName);
+    this._userJob = document.querySelector(userJob);
+  }
+
+  // возвращает объект с данными пользователя для вставки в форму при открытии
+  getUserInfo() {
+    return {
+    }
+  }
+
+  // принимает новые данные пользователя и добавляет их на страницу
+  setUserInfo(inputName, inputJob) {
+    this._userName.textContent = inputName.value;
+    this._userJob.textContent = inputJob.value;
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,69 +2,92 @@ import Section from '../components/Section.js';
 import FormValidator from '../components/FormValidator.js';
 import Card from '../components/Card.js';
 import PopupWithImage from '../components/PopupWithImage.js';
+import PopupWithForm from '../components/PopupWithForm.js';
+import UserInfo from '../components/UserInfo.js';
+
 import {
   initialCards,
-  validationConfig,
-  // popupEditProfile,
-  popupFormEditProfile,
+  // validationConfig,
+  EditProfileElement,
+  // popupFormEditProfile,
   // nameInput,
   // aboutInput,
-  // profileName,
-  // profileAbout,
-  // popupAddCard,
-  popupFormAddCard,
-  // cardNameInput,
-  // cardImageInput,
-  // addCardButton,
-  // cardTemplate,
+  addCardElement,
+  // popupFormAddCard,
+  cardNameInput,
+  cardImageInput,
+  addCardButton,
+  profileEditButton,
+  popupPreview,
+  cardTemplate,
   cardsContainerElement
 } from '../utils/constants.js';
 
-const editProfileFormValidity = new FormValidator(validationConfig, popupFormEditProfile);
-const addCardFormValidity = new FormValidator(validationConfig, popupFormAddCard);
 
-const fullsizePreview = new PopupWithImage('.popup_preview');
+
+const fullsizePreview = new PopupWithImage(popupPreview);
 fullsizePreview.setEventListeners();
+
+// функция для получения карточки (чтобы не дублировать код в экземплярах классов)
+const createCard = (item) => {
+  const card = new Card({
+    card: item,
+    handleOpenPreview: () => fullsizePreview.open(card)
+  }, cardTemplate);
+  return card
+}
 
 // экземпляр класса Section, рендерящий массив дефолтных карточек на страницу
 const defaultCardList = new Section({
     items: initialCards,
-    renderer: (cardItem) => {
-      const card = new Card({
-        card: cardItem,
-        handleOpenPreview: (evt) => fullsizePreview.open(evt)
-      }, '.elements__template');
+    renderer: (item) => {
+      const card = createCard(item);
       const cardElement = card.generateCard();
       defaultCardList.addItem(cardElement);
     },
   },
   cardsContainerElement
 );
+defaultCardList.renderItems();
 
-// // инициализация попапа добавления карточки
-// function initAddNewCardPopup() {
-//   addCardButton.addEventListener('click', () => {
-//     popupFormAddCard.reset();
-//     openPopup(popupAddCard);
-//   });
-// }
+// экземпляр класса PopupWithForm, отвечает за сбор данных из инпутов и вывод карточки на страницу
+const popupAddCard = new PopupWithForm({
+  popupSelector: addCardElement,
+  handleForm: () => {
+    const card = createCard({image: cardImageInput.value, name: cardNameInput.value});
+    const cardElement = card.generateCard();
+    defaultCardList.addItem(cardElement);
+    popupAddCard.close();
+  }
+});
+popupAddCard.setEventListeners();
+
+// // экземпляр класса PopupWithForm, собирает данные из инпутов попапа редактирования профиля и выводит информацию о пользователе на страницу
+// const popupEdit = new PopupWithForm({
+//   popupSelector: EditProfileElement,
+//   handleFormSubmit: ({inputName, inputJob}) => {
+//     return userProfileInfo.setUserInfo({inputName, inputJob});
+//   }
+// })
+// popupEdit.setEventListeners();
 //
-// // добавление новых карточек
-// function addNewCard() {
-//   const cardName = cardNameInput.value;
-//   const cardImage = cardImageInput.value;
-//   const card = new Card({name: cardName, image: cardImage}, '.elements__template');
-//   const cardElement = card.generateCard();
-//   cardsContainerElement.prepend(cardElement);
-//   popupFormAddCard.reset();
-// }
-//
-// // подтверждение создания карточки
-// function handleAddCardFormSubmit(evt) {
-//   evt.preventDefault();
-//   addNewCard();
-//   closePopup(popupAddCard);
-// }
+// const userProfileInfo = new UserInfo({profileName, profileAbout});
+
+
+
+
+
+
+
+
+
+
+
+
+
+// const editProfileFormValidity = new FormValidator(validationConfig, popupFormEditProfile);
+// const addCardFormValidity = new FormValidator(validationConfig, popupFormAddCard);
+
 //
 // // инициализация попапа редактирования профиля
 // function initEditProfilePopup() {
@@ -85,49 +108,17 @@ const defaultCardList = new Section({
 //   closePopup(popupEditProfile);
 // }
 //
-// // открытие попапа
-// export function openPopup(popup) {
-//   document.addEventListener('keydown', closeByPressingEscape);
-//   document.addEventListener('click', closeByClickingOverlay);
-//   popup.classList.add('popup_opened');
-// }
-//
-// // закрытие попапа
-// function closePopup(popup) {
-//   document.removeEventListener('keydown', closeByPressingEscape);
-//   document.removeEventListener('click', closeByClickingOverlay);
-//   popup.classList.remove('popup_opened');
-// }
-//
-// // закрытие попапа по нажатию на Esc
-// function closeByPressingEscape(evt) {
-//   if (evt.key === 'Escape') {
-//     const activePopup = document.querySelector('.popup_opened');
-//     closePopup(activePopup);
-//   }
-// }
-//
-// закрытие попапа по клику мимо окна
-// function closeByClickingOverlay(evt) {
-//   if (evt.target.classList.contains('popup_opened')) {
-//     const activePopup = document.querySelector('.popup_opened');
-//     closePopup(activePopup);
-//   }
-// }
-//
-// // обработчик клика по крестику
-// popupCloseButtons.forEach((closeButton) => {
-//   closeButton.addEventListener('click', function (evt) {
-//     closePopup(evt.target.closest('.popup'));
-//   });
-// })
 
-// popupFormEditProfile.addEventListener('submit', handleEditProfileFormSubmit);
-// popupFormAddCard.addEventListener('submit', handleAddCardFormSubmit);
+// листнер кнопки добавления карточки
+addCardButton.addEventListener('click', () => {
+  popupAddCard.open();
+});
 
+// profileEditButton.addEventListener('click', () => {
+//   popupEdit.open();
+//   console.log(popupEdit.popupSelector);
+// });
 
-defaultCardList.renderItems();
-// initEditProfilePopup();
-// initAddNewCardPopup();
-editProfileFormValidity.enableValidation();
-addCardFormValidity.enableValidation();
+// editProfileFormValidity.enableValidation();
+// addCardFormValidity.enableValidation();
+

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -35,17 +35,23 @@ export const validationConfig = {
   buttonInvalidClass: 'popup__save-button_invalid'
 }
 
-export const popupEditProfile = document.querySelector('.popup_edit-profile');
-export const popupFormEditProfile = popupEditProfile.querySelector('.popup__form_edit-profile');
+export const EditProfileElement = document.querySelector('.popup_edit-profile');
+export const popupFormEditProfile = EditProfileElement.querySelector('.popup__form_edit-profile');
 export const nameInput = popupFormEditProfile.querySelector('.popup__input[name="profileName"]');
 export const aboutInput = popupFormEditProfile.querySelector('.popup__input[name="profileAbout"]');
 export const profileName = document.querySelector('.profile__name');
 export const profileAbout = document.querySelector('.profile__about');
 
-export const popupAddCard = document.querySelector('.popup_add-card');
-export const popupFormAddCard = popupAddCard.querySelector('.popup__form_add-card');
+export const addCardElement = document.querySelector('.popup_add-card');
+export const popupFormAddCard = addCardElement.querySelector('.popup__form_add-card');
 export const cardNameInput = popupFormAddCard.querySelector('.popup__input[name="cardName"]');
 export const cardImageInput = popupFormAddCard.querySelector('.popup__input[name="cardImage"]');
+
 export const addCardButton = document.querySelector('.profile__add-button');
+export const profileEditButton = document.querySelector('.profile__edit-button');
+
+export const popupPreview = document.querySelector('.popup_preview');
+
+export const cardTemplate = document.querySelector('.elements__template');
 
 export const cardsContainerElement = document.querySelector('.elements__list');


### PR DESCRIPTION
Фуф, нужно чаще коммитить. Здесь получилось очень много всякого. Прежде всего написан и выполняет свои функции класс PopupWithForm, наследуемый от Popup. Он помимо прочего принимает в конструктор колбэк сабмита формы. Работает пока только с формой добавления карточек, на очереди редактирование профиля.
Помимо прочего:

**Card**
* Расширил метод generateCard(), дополнил парочкой переменных для удобства.
* То же самое сделал в _setEventListeners(), определил элементы лайка, корзины удаления и картинку карточку в переменные, чтобы было удобнее к ним обращаться.

**Section**
* В методе addItem() поменял append на prepend чтобы картинка вставлялись в начало сетки, а не в конец.

**Popup**
* this._popup теперь ссылается на параметр конструктора, а не на DOM-элемент с параметром.

**PopupWithImage**
* Переписал логику класса, отказался от завязки на event.target по картинке карточки.

**index.js**
* Разброд и шатание в импортах. Временно.
* Переписаны инстансы классов в соответствии с их новым содержанием.
* Есть заготовка под попап редактирования профиля, но не работает :)