### PR TITLE
fix(userinfo.js): поменять элементы на селекторы

### DIFF
--- a/src/components/UserInfo.js
+++ b/src/components/UserInfo.js
@@ -1,22 +1,22 @@
 // класс отвечает за управление отображением информации о пользователе на странице
 export default class UserInfo {
   constructor(userNameSelector, userAboutSelector) {
-    this._userNameSelector = userNameSelector;
-    this._userAboutSelector = userAboutSelector;
+    this._userNameElement = document.querySelector(userNameSelector);
+    this._userAboutElement = document.querySelector(userAboutSelector);
   }
 
   // возвращает объект с данными пользователя для вставки в форму при открытии
   getUserInfo() {
     const userInfo = {
-      name: this._userNameSelector.textContent,
-      about: this._userAboutSelector.textContent
+      name: this._userNameElement.textContent,
+      about: this._userAboutElement.textContent
     }
     return userInfo
   }
 
   // принимает новые данные пользователя и добавляет их на страницу
   setUserInfo(inputName, inputAbout) {
-    this._userNameSelector.textContent = inputName.value;
-    this._userAboutSelector.textContent = inputAbout.value;
+    this._userNameElement.textContent = inputName.value;
+    this._userAboutElement.textContent = inputAbout.value;
   }
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -29,8 +29,8 @@ export const EditProfileElement = document.querySelector('.popup_edit-profile');
 export const popupFormEditProfile = EditProfileElement.querySelector('.popup__form_edit-profile');
 export const nameInput = popupFormEditProfile.querySelector('.popup__input[name="profileName"]');
 export const aboutInput = popupFormEditProfile.querySelector('.popup__input[name="profileAbout"]');
-export const profileName = document.querySelector('.profile__name');
-export const profileAbout = document.querySelector('.profile__about');
+export const profileName = '.profile__name';
+export const profileAbout = '.profile__about';
 
 export const addCardElement = document.querySelector('.popup_add-card');
 export const popupFormAddCard = addCardElement.querySelector('.popup__form_add-card');


### PR DESCRIPTION
Согласно ТЗ конструктор класса должен принимать селекторы, а не элементы. Для этого изменил пару переменных в constants.js, присвоил им строковые значения с селекторами, и уже их передавал в изменённый конструктор, где по селекторами ищутся DOM-элементы.