### PR TITLE
fix(PopupWithImage.js): починить превью карточки

### DIFF
--- a/src/components/PopupWithImage.js
+++ b/src/components/PopupWithImage.js
@@ -8,7 +8,7 @@ export default class PopupWithImage extends Popup {
   };
 
   open(card) {
-    this._previewImage.src = card._image;
+    this._previewImage.src = card._link;
     this._previewImage.alt = card._name;
     this._previewCaption.textContent = card._name;
     super.open();


### PR DESCRIPTION
Большая картинка сломалась в процессе перевода на другие рельсы. Значение src картинки бралось из card._image, а нужно было из card._link. Исправлено.